### PR TITLE
Create an afterError method to specifically target failed $fh.cloud calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,31 @@ Cloud.after('/data', function (response) {
 });
 ```
 
+#### .afterError([route, validators, ]fn)
+Almost the same as _after_, but it will run run _fn_ on the response 
+received by $fh.cloud if the request failed. Also, the rejection 
+object passed into _fn_ will contain any data in the failed response 
+in rejection.data, the response's status as rejection.status as well 
+as the original request's options in rejection.options.
+
+If _fn_ resolves successfully, the Cloud call will be resolved successfully.
+If _fn_ resolves unsuccessfully, the Cloud call will be resolved unsuccessfully.
+
+Example usage of _afterError_:
+
+```javascript
+// Upon receiving a 401 response do something and try request again
+Cloud.afterError('/data', function (rejection) {
+  if (response.status === 401) {
+    // Do something fancy then try again
+    return fixAuthProblem().then(function() {
+      Cloud.request(rejection.options);
+    });
+  }
+  return $q.reject(rejection);
+});
+```
+
 ### FHHash
 Promise based interface to FeedHenry SDK hashing functions. All calls return a 
 promise. The injected variable _FHHash_ is a function with other shortcut 

--- a/dist/ngFH.js
+++ b/dist/ngFH.js
@@ -10557,7 +10557,7 @@ module.exports = function Preprocessors ($q, $timeout) {
     execAfterError: function (params, deferred) {
       var self = this;
       var processors = this.getProcessorsForRoute(
-        this.preprocessors.after, params.path);
+        this.preprocessors.afterError, params.path);
 
       return function (res) {
         return self.exec(processors, res)

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "linelint": "0.0.2",
     "jshint": "^2.5.3",
     "lintspaces-cli": "0.0.4",
-    "fh-mocks": "0.0.5",
+    "fh-mocks": "~0.0.5",
     "karma-mocha-reporter": "~0.3.1"
   },
   "dependencies": {

--- a/src/factories/Processors.js
+++ b/src/factories/Processors.js
@@ -151,7 +151,7 @@ module.exports = function Preprocessors ($q, $timeout) {
     execAfterError: function (params, deferred) {
       var self = this;
       var processors = this.getProcessorsForRoute(
-        this.preprocessors.after, params.path);
+        this.preprocessors.afterError, params.path);
 
       return function (res) {
         return self.exec(processors, res)

--- a/src/factories/Processors.js
+++ b/src/factories/Processors.js
@@ -20,6 +20,12 @@ module.exports = function Preprocessors ($q, $timeout) {
           stack: [],
           matcher: null
         }
+      },
+      afterError: {
+        '*': {
+          stack: [],
+          matcher: null
+        }
       }
     },
 
@@ -36,6 +42,12 @@ module.exports = function Preprocessors ($q, $timeout) {
             stack: [],
             matcher: null
           }
+        },
+        afterError: {
+          '*': {
+            stack: [],
+            matcher: null
+          }
         }
       };
     },
@@ -46,6 +58,10 @@ module.exports = function Preprocessors ($q, $timeout) {
 
     after: function (route, validators, fn) {
       this.use(this.preprocessors.after, route, validators, fn);
+    },
+
+    afterError: function (route, validators, fn) {
+      this.use(this.preprocessors.afterError, route, validators, fn);
     },
 
     use: function (processors, route, validators, fn) {
@@ -122,6 +138,17 @@ module.exports = function Preprocessors ($q, $timeout) {
     },
 
     execAfter: function (params, deferred) {
+      var self = this;
+      var processors = this.getProcessorsForRoute(
+        this.preprocessors.after, params.path);
+
+      return function (res) {
+        return self.exec(processors, res)
+          .then(deferred.resolve, deferred.reject);
+      };
+    },
+
+    execAfterError: function (params, deferred) {
       var self = this;
       var processors = this.getProcessorsForRoute(
         this.preprocessors.after, params.path);

--- a/test/services/Processors.js
+++ b/test/services/Processors.js
@@ -58,6 +58,12 @@ describe('Processors', function () {
       expect(Pre.preprocessors.after['/users'].stack[0].fn).to.equal(dummyFn);
     });
 
+    it('Should add the given route and function to the afterError stack', function () {
+      Pre.use(Pre.preprocessors.afterError, '/users', dummyFn);
+      expect(Pre.preprocessors.afterError['/users'].stack).to.have.length(1);
+      expect(Pre.preprocessors.afterError['/users'].stack[0].fn).to.equal(dummyFn);
+    });
+
     it('Should add th given functions to the same before route', function () {
       Pre.use(Pre.preprocessors.before, '/users', dummyFn);
       Pre.use(Pre.preprocessors.before, '/users', dummyFn);


### PR DESCRIPTION
The _after_ methods get executed on both a successful and failed $fh.cloud call (even though the documentation says "run fn on the response received by $fh.cloud if the request was successful"); I've got no way to tell whether or not I'm looking at a successful call unless I inspect the response.

This creates a specific processor set to handle failed $fh.cloud calls. Additionally, this exposes some information like the failure status code as well as the options from the original request and allows users the option of still "passing" the failed $fh.cloud call.

This is a potentially breaking change for people relying on _after_ to run after both successful and failed _$fh.cloud_ calls.
