### PR TITLE
Changed module.exports to export the angular module name as a string

### DIFF
--- a/src/ngFH.js
+++ b/src/ngFH.js
@@ -1,8 +1,10 @@
 'use strict';
 
 // Register ngFH module
-var app = module.exports = angular.module('ngFeedHenry', ['ng']);
+var ngModule = angular.module('ngFeedHenry', ['ng']);
 
 // Bind our modules to ngFH
-require('./factories')(app);
-require('./services')(app);
+require('./factories')(ngModule);
+require('./services')(ngModule);
+
+module.exports = 'ngFeedHenry';


### PR DESCRIPTION
As recommended in this npm blog post I've change the module exports to export the angular module name as a string.

http://blog.npmjs.org/post/114584444410/using-angulars-new-improved-browserify-support

This makes it a one-liner to consume the module in an angular client:

```
angular.module('app', [
  require('ng-feedhenry') // resolves to a string
])
```
